### PR TITLE
Restart cloudbenchmarks after update action is run

### DIFF
--- a/actions/update
+++ b/actions/update
@@ -1,7 +1,14 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 cd /opt/cloud-benchmarks
+
+PREV_COMMIT=`git rev-parse @`
 git pull
+
 python $CHARM_DIR/hooks/hooks.py
+
+if ! git diff --name-only $PREV_COMMIT...@ | grep -q production.ini; then
+  service cloudbenchmarks restart
+fi


### PR DESCRIPTION
I noticed when using cloud-benchmarks charm, the update action would pull but the site won't update until the service is restarted.

Not sure if this is an issue with the logic in hooks.py or an oversight.
